### PR TITLE
chore: add CODEOWNERS to require maintainer approval on PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nhs-england-tools/nhs-england-tools-maintainers


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Add a `CODEOWNERS` file to require approval from the `nhs-england-tools-maintainers` team on all pull requests.

## Context

Without a `CODEOWNERS` file, there is no enforced review requirement tied to a specific team. This change ensures that all PRs must be approved by a member of the `@nhs-england-tools/nhs-england-tools-maintainers` group before merging.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
